### PR TITLE
[BUG] Fix export image to andorid

### DIFF
--- a/Sources/FigmaExport/Subcommands/ExportImages.swift
+++ b/Sources/FigmaExport/Subcommands/ExportImages.swift
@@ -225,10 +225,10 @@ extension FigmaExportCommand {
             logger.info("Downloading remote files...")
             let remoteFiles = images.flatMap { asset -> [FileContents] in
                 var result = [FileContents]()
-                if case ImagePack.individualScales(let images) = asset.light {
+                if case ImagePack.images(let images) = asset.light {
                     result.append(contentsOf: makeRemoteFiles(images: images, dark: false, outputDirectory: tempDirectoryURL))
                 }
-                if let darkImages = asset.dark, case ImagePack.individualScales(let images) = darkImages {
+                if let darkImages = asset.dark, case ImagePack.images(let images) = darkImages {
                     result.append(contentsOf: makeRemoteFiles(images: images, dark: true, outputDirectory: tempDirectoryURL))
                 }
                 return result
@@ -284,11 +284,10 @@ extension FigmaExportCommand {
         ///   - images: Dictionary of images. Key = scale, value = image info
         ///   - dark: Dark mode?
         ///   - outputDirectory: URL of the output directory
-        private func makeRemoteFiles(images: [Double: Image], dark: Bool, outputDirectory: URL) -> [FileContents] {
-            var result: [FileContents] = []
-            for scale in images.keys {
-                guard let image = images[scale] else { continue }
+        private func makeRemoteFiles(images: [Image], dark: Bool, outputDirectory: URL) -> [FileContents] {
+            images.map { image -> FileContents in
                 let fileURL = URL(string: "\(image.name).\(image.format)")!
+                let scale = image.scale
                 let dest = Destination(
                     directory: outputDirectory
                         .appendingPathComponent(dark ? "dark" : "light")
@@ -297,9 +296,8 @@ extension FigmaExportCommand {
                 var file = FileContents(destination: dest, sourceURL: image.url)
                 file.scale = scale
                 file.dark = dark
-                result.append(file)
+                return file
             }
-            return result
         }
     }
 }

--- a/Sources/FigmaExportCore/Image.swift
+++ b/Sources/FigmaExportCore/Image.swift
@@ -35,15 +35,12 @@ public enum ImagePack: Asset {
     public typealias Scale = Double
     
     case singleScale(Image)
-    case individualScales([Scale: Image])
     case images([Image])
 
     public var single: Image {
         switch self {
         case .singleScale(let image):
             return image
-        case .individualScales:
-            fatalError("Unable to extract image from image pack")
         case .images:
             fatalError("Unable to extract image from image pack")
         }
@@ -54,8 +51,6 @@ public enum ImagePack: Asset {
             switch self {
             case .singleScale(let image):
                 return image.name
-            case .individualScales(let images):
-                return images.first!.value.name
             case .images(let images):
                 return images.first!.name
             }
@@ -65,11 +60,6 @@ public enum ImagePack: Asset {
             case .singleScale(var image):
                 image.name = newValue
                 self = .singleScale(image)
-            case .individualScales(var images):
-                for key in images.keys {
-                    images[key]?.name = newValue
-                }
-                self = .individualScales(images)
             case .images(let images):
                 let image = images.map { image -> Image in
                     var newImage = image
@@ -85,8 +75,6 @@ public enum ImagePack: Asset {
         switch self {
         case .singleScale(let image):
             return image.platform
-        case .individualScales(let images):
-            return images.first?.value.platform
         case .images(let images):
             return images.first?.platform
         }

--- a/Sources/XcodeExport/XcodeImagesExporter.swift
+++ b/Sources/XcodeExport/XcodeImagesExporter.swift
@@ -89,10 +89,6 @@ final public class XcodeImagesExporter: XcodeImagesExporterBase {
         switch pack {
         case .singleScale(let image):
             return [saveImage(image, to: directory, dark: dark)]
-        case .individualScales(let images):
-            return images.map { scale, image -> FileContents in
-                saveImage(image, to: directory, scale: scale, dark: dark)
-            }
         case .images(let images):
             return images.map { saveImage($0, to: directory, scale: $0.scale, dark: dark) }
         }
@@ -125,10 +121,6 @@ final public class XcodeImagesExporter: XcodeImagesExporterBase {
         switch pack {
         case .singleScale(let image):
             return [imageDataForImage(image, dark: dark)]
-        case .individualScales(let images):
-            return images.map { scale, image -> XcodeAssetContents.ImageData in
-                imageDataForImage(image, scale: scale, dark: dark)
-            }
         case .images(let images):
             return images.map { imageDataForImage($0, scale: $0.scale, dark: dark) }
         }
@@ -188,15 +180,6 @@ private extension ImagePack {
                 return nil
             }
             return self
-        case .individualScales(let images):
-            let validImages = images.reduce(into: [Scale: Image]()) { result, info in
-                let (scale, image) = info
-                guard image.isValidForXcode(scale: scale) else {
-                    return
-                }
-                result[scale] = image
-            }
-            return .individualScales(validImages)
         case .images(let images):
             return .images(images.filter { $0.isValidForXcode(scale: $0.scale) })
         }


### PR DESCRIPTION
## Description

The `figma-export images` is broken for Android.

## Root cause 

The bug was caused by this [PR(supporting device idiom)](https://github.com/RedMadRobot/figma-export/pull/37).

The `loadPNGImages` method was changed to return `ImagePack.images`, and the `exportAndroidRasterImages` only accept `ImagePack.individualScales` so that no images is exported. 

## Change in this PR

- Skip idiom checking if target platform is `Android`.
- Update `makeRemoteFiles` method to set `scale` from `Image`.
- Remove `individualScales` case. The case is not used. 
